### PR TITLE
Fix tmux window navigation conflict with vim-tmux-navigator

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -74,6 +74,9 @@ set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'tmux-plugins/tmux-open'
 set -g @plugin 'tmux-plugins/tmux-yank'
 
+# vim-tmux-navigator settings
+set -g @vim_navigator_prefix_mapping_clear_screen ''  # Disable C-l clear screen mapping
+
 set -g @prefix_highlight_empty_prompt ' Tmux '
 set -g @prefix_highlight_prefix_prompt 'Wait'
 


### PR DESCRIPTION
## Summary
- Disabled vim-tmux-navigator's clear screen mapping to restore `Ctrl-b Ctrl-l` functionality for window navigation
- Added configuration to prevent vim-tmux-navigator from overriding the tmux window navigation keybinding

## Test plan
- [x] Verify `Ctrl-b Ctrl-l` moves to the next window
- [x] Verify `Ctrl-l` still works for vim/tmux pane navigation
- [x] Confirm no regression in vim-tmux-navigator functionality

🤖 Generated with [Claude Code](https://claude.ai/code)