### PR TITLE
CLAUDE.mdの正確性と簡潔さを改善

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,4 +13,4 @@
 
 ## General Development Rules
 - Follow existing project patterns and conventions
-- Always use TodoWrite tool for task planning
+- Use the task tracking tools (TaskCreate/TaskUpdate) for multi-step work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ brew bundle --file=Brewfile
 ### Core Structure
 - **Root dotfiles** (`.zshrc`, `.zshenv`, `.editorconfig`) - Shell and editor configurations
 - **`.config/`** - XDG Base Directory compliant configurations for tools like tmux, git, tig, etc.
-- **`.claude/`** - Claude Code specific configurations including hooks, commands, and agents
+- **`.claude/`** - Claude Code configuration: `settings.json` (plugins/hooks/preferences), `hooks/` (event scripts), `CLAUDE.md` (global instructions)
 - **`scripts/`** - Installation and setup scripts
 - **`Brewfile`** - Homebrew package definitions
 
@@ -61,6 +61,11 @@ Plugins from the official marketplace extend Claude Code's capabilities:
 - **feature-dev**: Guided feature development workflow
 - **pr-review-toolkit**: Comprehensive PR review with specialized agents
 - **skill-creator**: Skill creation and optimization
+
+#### Claude Code Hooks (`.claude/hooks/`)
+Event-driven scripts wired up via `.claude/settings.json`:
+- **notification-handler.sh**: Fires a macOS notification on Notification events
+- **langfuse_hook.py**: Sends session traces to Langfuse on Stop events
 
 ## Common Development Workflows
 
@@ -114,13 +119,3 @@ The install script creates symbolic links from the repository to the home direct
 - XDG config directory structure
 - Claude Code configurations
 - Exclusion of repository metadata
-
-### Plugin Ecosystem
-- **Zsh**: Managed by zinit with lazy loading for performance
-- **Tmux**: Managed by TPM with automatic installation
-- **Development tools**: Configured via Homebrew with consistent CLI experience
-
-### Environment Integration
-- Supports multiple development environments (Go, Node.js via nvm, Python via pyenv, Ruby via rbenv)
-- GNU tools preferred over BSD variants on macOS
-- XDG Base Directory specification compliance where possible


### PR DESCRIPTION
## Summary
`/claude-md-improver` の監査結果に基づき、CLAUDE.md を実態に合わせて修正:

- **`.claude/` の構造説明を更新** — `commands/`, `agents/` がプラグイン化により削除されたため、現状の `settings.json` / `hooks/` / `CLAUDE.md` 構成を明示
- **Claude Code Hooks セクションを追加** — `notification-handler.sh`, `langfuse_hook.py` の役割を1行ずつ記述
- **重複セクションを削除** — `Plugin Ecosystem` / `Environment Integration` は前段の `Shell Environment` / `Terminal Multiplexer` / `Development Tools Integration` と内容が重複していた
- **`TodoWrite` 参照を更新** — 現行 Claude Code には存在せず、`TaskCreate`/`TaskUpdate` が現行 API

差分: +8 / -13 行で dense になりました。

## Note
このPRは #108 (`add-claude-plugins`) をベースとしたスタックPRです。先に #108 をマージすると、自動的に `main` をベースに切り替わります。

## Test plan
- [ ] CLAUDE.md がプラグイン構成と整合していることを確認
- [ ] hooks の説明がスクリプトの実体と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)