### PR TITLE
Claude Codeのsandboxモードを設定

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,5 +34,47 @@
   },
   "language": "japanese",
   "alwaysThinkingEnabled": true,
-  "editorMode": "vim"
+  "editorMode": "vim",
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "excludedCommands": ["git", "ssh", "gh"],
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "*.github.com",
+        "raw.githubusercontent.com",
+        "objects.githubusercontent.com",
+        "codeload.github.com",
+        "registry.npmjs.org",
+        "pypi.org",
+        "files.pythonhosted.org",
+        "proxy.golang.org",
+        "sum.golang.org",
+        "crates.io",
+        "static.crates.io",
+        "formulae.brew.sh",
+        "*.googleapis.com",
+        "anthropic.com",
+        "*.anthropic.com"
+      ],
+      "allowLocalBinding": true
+    },
+    "filesystem": {
+      "denyRead": [
+        "~/.ssh/**",
+        "~/.aws/**",
+        "~/.gnupg/**",
+        "~/.config/gcloud/**",
+        "~/.config/gh/hosts.yml",
+        "~/.kube/config",
+        "~/.docker/config.json",
+        "~/.netrc",
+        "~/Library/Keychains/**",
+        "**/.env",
+        "**/.env.*"
+      ],
+      "allowWrite": ["~/.cache/**", "~/Library/Caches/**"]
+    }
+  }
 }

--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -1,3 +1,5 @@
 *~
 .DS_Store
 .idea
+
+**/.claude/settings.local.json


### PR DESCRIPTION
## Summary
- `.claude/settings.json` に sandbox 設定を追加 (`enabled`, `autoAllowBashIfSandboxed`, `excludedCommands`, `network`, `filesystem`)
- 資格情報ファイル (`~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gcloud`, `~/.kube/config`, `~/.docker/config.json`, `~/.netrc`, `~/Library/Keychains`, `**/.env`) をdenyReadでブロック
- `git` / `ssh` / `gh` を `excludedCommands` に追加 (denyReadで制限したcredential読み取りが必要なため、sandbox外で実行)
- `network.allowLocalBinding: true` を有効化 (dev server動作確保)
- 開発でよく使うドメイン (github/npm/pypi/golang/crates/brew/googleapis/anthropic) を `allowedDomains` に登録
- `.config/git/ignore` に `.claude/settings.local.json` を追加し、ローカル上書き設定をgit管理対象外に

## Test plan
- [ ] Claude Code を再起動してsandboxが有効化されることを確認
- [ ] ローカルbindするdev server (例: \`python3 -m http.server\`) がsandbox内で起動できることを確認
- [ ] Bashコマンドの権限プロンプトが大幅に減ることを確認 (autoAllowBashIfSandboxed効果)
- [ ] denyRead対象のcredentialファイルがsandbox内から読み取れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)