### PR TITLE
サンドボックスで .claude ディレクトリへの書き込みを許可

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -161,7 +161,8 @@
     "filesystem": {
       "allowWrite": [
         "~/.cache/**",
-        "~/Library/Caches/**"
+        "~/Library/Caches/**",
+        "**/.claude/**"
       ],
       "denyRead": [
         "~/.ssh/**",


### PR DESCRIPTION
## Summary
- サンドボックスの `filesystem.allowWrite` に `**/.claude/**` を追加し、各プロジェクトの `.claude/` 配下への書き込みを許可

## Test plan
- [ ] `.claude/` 配下のファイルに対する書き込み操作がサンドボックスでブロックされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)