### PR TITLE
Claude Code の worktree をグローバル gitignore に追加

### DIFF
--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -3,3 +3,4 @@
 .idea
 
 **/.claude/settings.local.json
+**/.claude/worktrees/


### PR DESCRIPTION
## Summary
- グローバル gitignore (`.config/git/ignore`) に `**/.claude/worktrees/` を追加
- Claude Code の agent isolation 機能で生成される worktree がリポジトリ管理対象に含まれないようにする

## Test plan
- [ ] `./install.sh` で symlink を更新後、`.claude/worktrees/` 配下のファイルが `git status` に現れないことを確認