### PR TITLE
Claude Code設定にエージェントチーム実験フラグを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "permissions": {
     "allow": [
       "Bash(git status*)",
@@ -131,7 +134,8 @@
     "feature-dev@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
-    "context7@claude-plugins-official": true
+    "context7@claude-plugins-official": true,
+    "terraform@claude-plugins-official": true
   },
   "language": "japanese",
   "sandbox": {
@@ -185,8 +189,5 @@
     ]
   },
   "alwaysThinkingEnabled": true,
-  "editorMode": "vim",
-  "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
-  }
+  "editorMode": "vim"
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -185,5 +185,8 @@
     ]
   },
   "alwaysThinkingEnabled": true,
-  "editorMode": "vim"
+  "editorMode": "vim",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
 }


### PR DESCRIPTION
## Summary
- `.claude/settings.json`に`env`セクションを新設し、`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`を設定
- Claude Codeのエージェントチーム機能(実験的)を有効化

## Test plan
- [ ] `./install.sh`を再実行してsymlinkが最新の状態で反映されることを確認
- [ ] Claude Code起動後、エージェントチーム関連ツール(TeamCreate等)が利用可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)